### PR TITLE
make bool_rand::bool() able to actually return true

### DIFF
--- a/src/bool_rand.rs
+++ b/src/bool_rand.rs
@@ -31,5 +31,5 @@ use crate::misc;
 /// Requires the "random-bool" feature.
 ///
 pub fn bool() -> bool {
-    misc::random::<i64>(0, 1) == 1
+    misc::random::<i64>(0, 2) == 1
 }


### PR DESCRIPTION
misc::random() takes an inclusive lower bound and exclusive upper bound