### PR TITLE
fix(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atomic"


### PR DESCRIPTION
`RUSTSEC-2026-0190`: `anyhow` < 1.0.103 has an `Error::downcast_mut()` unsoundness (undefined behavior when adding context via `Error::context` then calling `downcast_mut` on the result), failing `cargo audit`.

**Fix:** `cargo update -p anyhow` → **1.0.103** (patched ≥1.0.103). Lockfile-only.

Verified: `cargo audit` clean, `clippy --all --tests --all-features -D warnings` clean, `fmt --check` clean, tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
